### PR TITLE
remove fuzzy for two translations

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -315,7 +315,6 @@ msgid ""
 msgstr ""
 
 #: features.phtml:201
-#, fuzzy
 msgid ""
 "<span class=\"gnucash\">GnuCash</span> runs on many different operating "
 "systems including <b>Windows</b>, <b>MacOSX</b> and <b>Linux</b>."
@@ -337,7 +336,6 @@ msgstr ""
 "dieser Leistung beizutragen."
 
 #: features.phtml:55
-#, fuzzy
 msgid ""
 "A <b>summary bar</b> that displays all of the relevant account's balance "
 "information"


### PR DESCRIPTION
I've removed "fuzzy" entries from two translations. In my view, they are good - better than an unfinished translation: mix of German and English.