### PR TITLE
Update header.phtml

### DIFF
--- a/externals/header.phtml
+++ b/externals/header.phtml
@@ -34,12 +34,12 @@
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
 
     <!--meta properties for facebook Open Graph-->
-    <meta property="og:title" content="Free Accounting Software | GnuCash"/>
+    <meta property="og:title" content="<?=T_("Free Accounting Software")?> | GnuCash"/>
     <meta property="og:type" content="website"/>
     <meta property="og:url" content="https://www.gnucash.org/"/>
     <meta property="og:image" content="https://www.gnucash.org/externals/logo_w120.png"/>
     <meta property="og:site_name" content="GnuCash"/>
-    <meta property="og:description" content="A personal and small-business financial-accounting software, licensed under GNU/GPL and available for Linux, Windows, Mac OS X, BSD, and Solaris."/>
+    <meta property="og:description" content="<?=T_("<span class="gnucash">GnuCash</span> is personal and small-business financial-accounting software, freely licensed under the <a href="https://www.gnu.org/">GNU</a> GPL and available for GNU/Linux, BSD, Solaris, Mac OS X and Microsoft Windows.")?>"/>
     <!--end of Open Graph properties-->
 
     <?php } ?>
@@ -56,7 +56,7 @@
     <?php } ?>
 
     <!--This is the description shown on google+ profile for GnuCash-->
-    <meta name="description" content="A personal and small-business financial-accounting software, licensed under GNU/GPL and available for Linux, Windows, Mac OS X, BSD, and Solaris." />
+    <meta name="description" content="<?=T_("<span class="gnucash">GnuCash</span> is personal and small-business financial-accounting software, freely licensed under the <a href="https://www.gnu.org/">GNU</a> GPL and available for GNU/Linux, BSD, Solaris, Mac OS X and Microsoft Windows.")?>"/>
 
     <title><?= T_($title); ?> | GnuCash</title>
     <!--script for Google+1 button-->


### PR DESCRIPTION
To improve the multilinguality of the website in web-search results, I propose some changes in the meta tags of the <head> of the „header.phtml” file. The idea is to use translated text for the other languages.

Changes would be made for:
a) meta property="og:title"
b) meta property="og:description"
c) meta name="description"

It has something to do with php stuff. As I’m not a programmer, I’m not sure if this solution works, nor if it is legit. But something similar is being used in the „menu.phtml” file.
!!! Please see the diff between my new file and the orig file on master !!!

P.S.
I’ve checked my „experiment” at https://metatags.io/
It seems that html-tags within then strings don’t matter (which I was afraid of).

If my changes don’t work, maybe somebody knows how to handle the issue. But that would probably be something for a feature request ...