### PR TITLE
Add docker compose for easier contributions

### DIFF
--- a/README
+++ b/README
@@ -19,9 +19,19 @@ Requirements
 - gettext
 - PHP (7 recommended)
 
--------------------------------------------------
-Notes about multi-lingual gnucash website content
--------------------------------------------------
+## Running
+
+- Clone the project and run with php 7 and apache
+
+  or
+
+- `docker compose up`
+
+and access http://localhost:8000/index.phtml
+
+Optional: if you are working with css and html is faster to develop using some
+hot reolading like https://github.com/blaise-io/live-reload#readme
+
 
 - all pages must call lang.php to bring in gettext support.
 - It would be nice to use the same containing structure for all translations.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+services:
+  php-apache-environment:
+    container_name: php-apache-environment
+    image: php:7.4-apache
+    volumes:
+      - ./:/var/www/html/
+    ports:
+      - 8000:80


### PR DESCRIPTION
It's easier to run just `docker compose up` than to install php and apache in the correct versions.

I for example don't have php installed and have bad memories managing versions in the past.